### PR TITLE
Generation of Snakeoil certificates

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -15,10 +15,24 @@ platforms:
 
 suites:
   - name: default
-    run_list: cop_tls::dhparams
+    run_list:
+    - recipe[cop_tls::dhparams]
+    - recipe[cop_tls::snakeoil]
     attributes:
         tls:
             dhparams:
                 files:
                     - /etc/ssl/certs/dhparams.pem
                     - /tmp/dhparams.pem 
+            snakeoil:
+                certs:
+                    test.localhost.com:
+                        bits: 2048
+                        days: 400
+                        country: US
+                        state: Oregon
+                        city: Portland
+                        company: Copious
+                        section: Devoops
+                        hostname: test.localhost.com
+                        contact: satan@copiousdev.com

--- a/README.md
+++ b/README.md
@@ -2,9 +2,59 @@
 
 A collection of common cryptographic recipes.
 
-## TODO
+## Major Attributes
+* `default['tls']['dhparams']['files'] = []` Needs to be an hash or array of
+  file paths. By default this is `/etc/ssl/certs/dhparams.pem`
+* `default['tls']['snakeoil']['certs'] = []` Needs to be an hash or array of
+  *named* dictionaries. By default this is empty. You need to create these
+attributes in a role or environment file.
 
-* [x] dhparams
-* [ ] snakeoil generation
-* [ ] ???
-* [ ] profit
+## Minor Attributes
+* `default['tls']['dhparams']['bits'] = N` Needs to be an integer. This changes
+  the bit number used in generation. Defaults to `2048`.
+* `default['tls']['snakeoil']['certs'][...]['bits'] = []` Needs to be an
+  integer. This changes the bit number used in generation. Defaults to `2048`.
+* `default['tls']['snakeoil']['certs'][...]['days'] = []` Needs to be an
+  integer. This changes the expiration length, in days, of a certificate. Defaults to
+`365` days.
+
+## Usage
+The `cop_tls` default recipe is blank on purpose. Add either `dhparams` or
+`snakeoil` recipes into the run_list to install either component.
+
+The example below will create a wildcard certificate called `_.localhost.com.crt` in
+`/etc/ssl/certs` and its key, `_.localhost.com.key`, in `/etc/ssl/private`.
+
+```ruby
+name 'certs'
+description 'installs and configures a snakeoil cert with matching dhparams'
+
+override_attributes(
+    ...
+    'tls' => {
+        'dhparams' => {
+            'files' => %w{
+                /etc/ssl/certs/dhparams.pem
+            }
+        },
+        'snakeoil' => {
+            'certs' => {
+                '_.localhost.com' => {
+                    'country'  => 'US',
+                    'state'    => 'OR',
+                    'city'     => 'PDX',
+                    'company'  => 'Copious',
+                    'section'  => 'Sysadmin',
+                    'hostname' => '*.localhost.com',
+                    'contact'  => 'support@copiousdev.com'
+                }
+            }
+        }
+    },
+    ...
+)
+
+run_list(
+    'recipe[cop_tls::dhparams]','recipe[cop_tls::snakeoil]'
+)
+```

--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@ attributes in a role or environment file.
 ## Minor Attributes
 * `default['tls']['dhparams']['bits'] = N` Needs to be an integer. This changes
   the bit number used in generation. Defaults to `2048`.
-* `default['tls']['snakeoil']['certs'][...]['bits'] = []` Needs to be an
+* `default['tls']['snakeoil']['certs'][...]['bits'] = N` Needs to be an
   integer. This changes the bit number used in generation. Defaults to `2048`.
-* `default['tls']['snakeoil']['certs'][...]['days'] = []` Needs to be an
+* `default['tls']['snakeoil']['certs'][...]['days'] = N` Needs to be an
   integer. This changes the expiration length, in days, of a certificate. Defaults to
 `365` days.
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,6 +1,8 @@
 default['tls']['container'] = '/etc/ssl'
+default['tls']['cert_path'] = "#{node['tls']['container']}/certs"
+default['tls']['key_path']  = "#{node['tls']['container']}/private"
 
 default['tls']['dhparams']['bits']  = 2048
-default['tls']['dhparams']['files'] = %w(
-    /etc/ssl/certs/dhparams.pem
+default['tls']['dhparams']['files'] = %W(
+    #{default['tls']['cert_path']}/dhparams.pem
 )

--- a/recipes/common.rb
+++ b/recipes/common.rb
@@ -3,20 +3,14 @@
 # Recipe:: common
 #
 
-directory node['tls']['container'] do
-    owner  'root'
-    group  'root'
-    mode   0755
-    action :create
-end
-
-dirs = %w(
-    certs
-    private
-)
+dirs = [
+    node['tls']['container'],
+    node['tls']['cert_path'],
+    node['tls']['key_path']
+]
 
 dirs.each do |dir|
-    directory "#{node['tls']['container']}/#{dir}" do
+    directory dir do
         owner  'root'
         group  'root'
         mode   0755

--- a/recipes/snakeoil.rb
+++ b/recipes/snakeoil.rb
@@ -1,0 +1,44 @@
+#
+# Cookbook Name:: cop_tls
+# Recipe:: snakeoil
+#
+
+include_recipe 'cop_tls::common'
+
+if node['tls']['snakeoil']['certs']
+    node['tls']['snakeoil']['certs'].each do |file,data|
+        cert = "#{node['tls']['cert_path']}/#{file}.crt"
+        key  = "#{node['tls']['key_path']}/#{file}.key"
+        bits = data['bits'] || '2048'
+        days = data['days'] || '365'
+
+        execute "generating #{file}" do
+            command "
+    answers() {
+            echo #{data['country']}
+            echo #{data['state']}
+            echo #{data['city']}
+            echo #{data['company']}
+            echo #{data['section']}
+            echo #{data['hostname']}
+            echo #{data['contact']}
+    }
+
+    answers | /usr/bin/openssl req -newkey rsa:#{bits} -keyout #{key} -nodes -x509 -days #{days} -out #{cert}"
+            creates cert
+        end
+
+        files = [
+            cert,
+            key
+        ]
+
+        files.each do |f|
+            file f do
+                owner 'root'
+                group 'root'
+                mode  0700
+            end
+        end
+    end
+end

--- a/test/integration/default/serverspec/snakeoil_spec.rb
+++ b/test/integration/default/serverspec/snakeoil_spec.rb
@@ -1,0 +1,46 @@
+require 'spec_helper'
+
+describe 'cop_tls::snakeoil' do
+  describe file('/etc/ssl') do
+    it { should be_directory }
+    it { should be_owned_by 'root' }
+    it { should be_grouped_into 'root' }
+    it { should be_mode 755 }
+  end
+
+  describe file('/etc/ssl/certs') do
+    it { should be_directory }
+    it { should be_owned_by 'root' }
+    it { should be_grouped_into 'root' }
+    # NOTE: in some installations this can be a symlink, which is 777
+    #       we can skip this check
+    #it { should be_mode 755 }
+  end
+
+  describe file('/etc/ssl/certs/test.localhost.com.crt') do
+    it { should be_file }
+    it { should be_owned_by 'root' }
+    it { should be_grouped_into 'root' }
+    it { should be_mode 700 }
+    its(:content) { should match /BEGIN CERTIFICATE/ }
+    its(:content) { should match /END CERTIFICATE/ }
+  end
+
+  describe file('/etc/ssl/private/test.localhost.com.key') do
+    it { should be_file }
+    it { should be_owned_by 'root' }
+    it { should be_grouped_into 'root' }
+    it { should be_mode 700 }
+    its(:content) { should match /BEGIN PRIVATE KEY/ }
+    its(:content) { should match /END PRIVATE KEY/ }
+  end
+
+  describe command('sudo openssl x509 -in /etc/ssl/certs/test.localhost.com.crt -text -noout') do
+    its(:stdout) { should match /C=US/ }
+    its(:stdout) { should match /ST=Oregon/ }
+    its(:stdout) { should match /L=Portland/ }
+    its(:stdout) { should match /O=Copious/ }
+    its(:stdout) { should match /OU=Devoops/ }
+    its(:stdout) { should match /CN=test\.localhost\.com/ }
+  end
+end


### PR DESCRIPTION
Basic certificates through Chef. Please review and comment as you see fit.

At this point it only handles self-signed certificates and dhparams. Future work can include LetsEncrypt or others.