### PR TITLE
Install certificates

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -18,8 +18,13 @@ suites:
     run_list:
     - recipe[cop_tls::dhparams]
     - recipe[cop_tls::snakeoil]
+    - recipe[cop_tls::install_certs]
     attributes:
         tls:
+            certs:
+                test.localhost.org:
+                    cert: 'certificate goes here'
+                    key: 'private key goes here'
             dhparams:
                 bits: 512
                 files:

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -10,4 +10,5 @@ default['tls']['dhparams']['files'] = %W(
 )
 
 # initialize empty array
+default['tls']['certs'] = []
 default['tls']['snakeoil']['certs'] = []

--- a/recipes/install_certs.rb
+++ b/recipes/install_certs.rb
@@ -1,0 +1,40 @@
+#
+# Cookbook Name:: cop_tls
+# Recipe:: install_certs
+#
+
+include_recipe 'cop_tls::common'
+
+certs = node['tls']['certs']
+
+unless certs.nil?
+    # NOTE: only merge when there are preexisting certs to be installed
+    #       this should prevent certs being loaded and installed in development
+    sensitive_info = begin
+                         data_bag_item('tls', node.chef_environment)['certs']
+                     rescue Net::HTTPServerException, Chef::Exceptions::InvalidDataBagPath
+                         # NOTE: setting to nil will skip the condition below
+                         nil
+                     end
+
+    # NOTE: merge sensitive values with certs attribute tree
+    if sensitive_info
+        node.default['tls']['certs'] = node['tls']['certs'].merge(sensitive_info)
+    end
+
+    certs.each do |file,data|
+        if data['cert']
+            file "#{node['tls']['cert_path']}/#{file}.crt" do
+                content data['cert']
+                mode 0644
+            end
+        end
+
+        if data['key']
+            file "#{node['tls']['key_path']}/#{file}.key" do
+                content data['key']
+                mode 0600
+            end
+        end
+    end
+end

--- a/test/integration/default/serverspec/install_certs_spec.rb
+++ b/test/integration/default/serverspec/install_certs_spec.rb
@@ -1,0 +1,19 @@
+require 'spec_helper'
+
+describe 'cop_tls::install_certs' do
+  describe file('/etc/ssl/certs/test.localhost.org.crt') do
+    it { should be_file }
+    it { should be_owned_by 'root' }
+    it { should be_grouped_into 'root' }
+    it { should be_mode 644 }
+    its(:content) { should match /certificate goes here/ }
+  end
+
+  describe file('/etc/ssl/private/test.localhost.org.key') do
+    it { should be_file }
+    it { should be_owned_by 'root' }
+    it { should be_grouped_into 'root' }
+    it { should be_mode 600 }
+    its(:content) { should match /private key goes here/ }
+  end
+end


### PR DESCRIPTION
Installs certificates from attributes. Supports pulling attributes from a databag. Includes tests on certificates installation, but not dealing with databags.